### PR TITLE
Define Deployment & Service for Rails application

### DIFF
--- a/deployments/mealplan.yml
+++ b/deployments/mealplan.yml
@@ -1,0 +1,50 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: mealplan
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mealplan
+        tier: backend
+        track: stable
+    spec:
+      containers:
+        - name: mealplan
+          image: "meal_plan:1"
+          ports:
+            - name: rails
+              containerPort: 3000
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: mealplan-config
+                  key: postgres_user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: mealplan-config
+                  key: postgres_password
+            - name: POSTGRES_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: mealplan-config
+                  key: postgres_host
+            - name: RAILS_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: mealplan-config
+                  key: rails_env
+            - name: RAILS_LOG_TO_STDOUT
+              valueFrom:
+                configMapKeyRef:
+                  name: mealplan-config
+                  key: rails_log_to_stdout
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                configMapKeyRef:
+                  name: mealplan-config
+                  key: secret_key_base

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,6 +24,8 @@ services:
     env_file: .env.prod
     volumes:
       - db-data:/var/lib/postgresql/db-data
+    ports:
+      - "5432:5432"
 
   prod_app:
     build:

--- a/services/mealplan.yml
+++ b/services/mealplan.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mealplan
+spec:
+  selector:
+    app: mealplan
+    tier: backend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: rails
+  type: LoadBalancer


### PR DESCRIPTION
This adds the configuration necessary to
repeatably create a Kubernetes deployment and service for our
backend rails application.

This does not run the database in Kubernetes or set up the frontend
Nginx deployment/service.